### PR TITLE
Update upsplus.py

### DIFF
--- a/upsplus.py
+++ b/upsplus.py
@@ -82,17 +82,18 @@ elif (aReceiveBuf[10] << 8 | aReceiveBuf[9])> 4000:
 else:
     print('-'*60)
     print('Currently not charging.')
+    
 # Consider shutting down to save data or send notifications
-    batteryVoltage = ina.voltage()
-    if (str(batteryVoltage)) == ("0.0"):
-        print("Bad battery voltage value")
-    if (str(batteryVoltage)) != ("0.0"):
-        if ((batteryVoltage * 1000) < (PROTECT_VOLT + 200)):
-            print('-'*60)
-            print('The battery is going to dead! Ready to shut down!')
+batteryVoltage = ina.voltage()
+if (str(batteryVoltage)) == ("0.0"):
+    print("Bad battery voltage value")
+if (str(batteryVoltage)) != ("0.0"):
+    if ((batteryVoltage * 1000) < (PROTECT_VOLT + 200)):
+        print('-'*60)
+        print('The battery is going to dead! Ready to shut down!')
 # It will cut off power when initialized shutdown sequence.
-            bus.write_byte_data(DEVICE_ADDR, 24,240)
-            os.system("sudo sync && sudo halt")
-            while True:
-                time.sleep(10)
+        bus.write_byte_data(DEVICE_ADDR, 24,240)
+        os.system("sudo sync && sudo halt")
+        while True:
+            time.sleep(10)
 


### PR DESCRIPTION
I have an UPSplus which, from time to time, stops charging, even the charger is still delivering power to the system.
In this situation the Raspberry is pwoered fro mthe batteries and they are getting empty. With the current implementation the graceful shutdown is never initialized since this case lies in the else clauss.
By moving the battery interrogation one indentation outwards, this erronous case is caught sanely.
Harry